### PR TITLE
添加更多的接口

### DIFF
--- a/example/example_md5.f90
+++ b/example/example_md5.f90
@@ -1,15 +1,21 @@
 program main
 
-    use SM3_module, only: MD5
-    use, intrinsic :: iso_c_binding, only: c_signed_char, c_size_t
+    use SM3_module
+    use, intrinsic :: iso_c_binding, only: c_int8_t, c_size_t
     implicit none
-    integer(c_signed_char) :: msg(3)
-    integer(c_signed_char) :: dgst(16)
+    integer(c_int8_t) :: msg(3)
+    integer(c_int8_t) :: dgst(MD5_DIGEST_SIZE)
+    type(MD5_CTX) :: ctx
 
     print '(a)', " **** MD5 demo: "
     msg = ichar(['a', 'b', 'c'])
-    call MD5(msg, 3_c_size_t, dgst)
+    call md5_digest(msg, 3_c_size_t, dgst)
     print '(a,*(4z0.2,:,1x))', '"abc"   : ', dgst
     ! "abc"   : 90015098 3CD24FB0 D6963F7D 28E17F72
 
+    call md5_init(ctx)
+    call md5_update(ctx, msg(1:2), 2_c_size_t)
+    call md5_update(ctx, msg(3:3), 1_c_size_t)
+    call md5_finish(ctx, dgst)
+    print '(a,*(4z0.2,:,1x))', '"abc"   : ', dgst
 end program main

--- a/example/example_sm3.f90
+++ b/example/example_sm3.f90
@@ -5,17 +5,20 @@
 !> 示例提供多种访问 SM3 接口的数据重塑方式
 program main
 
-    use SM3_module, only: SM3
-    use, intrinsic :: iso_c_binding, only: c_signed_char, c_size_t
+    use SM3_module
+    use, intrinsic :: iso_c_binding, only: c_int8_t, c_size_t
     implicit none
-    integer(c_signed_char) :: dgst(32)
-    integer(c_signed_char) :: msg(3) ! 'abc'
+    integer(c_int8_t) :: dgst(SM3_DIGEST_SIZE)
+    integer(c_int8_t) :: msg(3)  ! 'abc'
+    integer(c_int8_t) :: msg4(4) ! 'abcd'
     character(3) :: str = 'abc'
+    type(SM3_CTX) :: ctx
+    integer :: i
 
     print '(a)', " **** SM3 demo: "
     ! --------------------------- 字节 (bytes) ----------------------- !
     msg = [97, 98, 99]
-    call SM3(msg, 3_c_size_t, dgst)
+    call sm3_digest(msg, 3_c_size_t, dgst)
     print '(a,*(4z0.2,:,1x))', '"abc"   : ', dgst
     ! 66C7F0F4 62EEEDD9 D1F2D46B DC10E4E2 4167C487 5CF2F7A2 297DA02B 8F4BA8E0
 
@@ -23,7 +26,7 @@ program main
     msg(1) = int(Z'61')
     msg(2) = int(Z'62')
     msg(3) = int(Z'63')
-    call SM3(msg, 3_c_size_t, dgst)
+    call sm3_digest(msg, 3_c_size_t, dgst)
     print '(a,*(4z0.2,:,1x))', '"abc"   : ', dgst
     ! 66C7F0F4 62EEEDD9 D1F2D46B DC10E4E2 4167C487 5CF2F7A2 297DA02B 8F4BA8E0
 
@@ -31,19 +34,27 @@ program main
     msg(1) = ichar('a')
     msg(2) = ichar('b')
     msg(3) = ichar('c')
-    call SM3(msg, 3_c_size_t, dgst)
+    call sm3_digest(msg, 3_c_size_t, dgst)
     print '(a,*(4z0.2,:,1x))', '"abc"   : ', dgst
     ! 66C7F0F4 62EEEDD9 D1F2D46B DC10E4E2 4167C487 5CF2F7A2 297DA02B 8F4BA8E0
 
     ! ------------------ 类型重塑 (Type cast / string) ---------------- !
     msg = transfer(str, msg)
-    call SM3(msg, 3_c_size_t, dgst)
+    call sm3_digest(msg, 3_c_size_t, dgst)
     print '(a,*(4z0.2,:,1x))', '"abc"   : ', dgst
     ! 66C7F0F4 62EEEDD9 D1F2D46B DC10E4E2 4167C487 5CF2F7A2 297DA02B 8F4BA8E0
 
     ! ------------------------ demo2: "abcd"*4 ---------------------- !
-    call SM3(transfer(repeat('abcd', 16), msg), int(4*16, c_size_t), dgst)
+    call sm3_digest(transfer(repeat('abcd', 16), msg), int(4*16, c_size_t), dgst)
     print '(a,*(4z0.2,:,1x))', '"abcd"*4: ', dgst
     ! DEBE9FF9 2275B8A1 38604889 C18E5A4D 6FDB70E5 387E5765 293DCBA3 9C0C5732
 
+    call sm3_init(ctx)
+    msg4 = transfer("abcd", msg4)
+    do i = 1, 16
+        call sm3_update(ctx, msg4, 4_c_size_t)
+    end do
+    call sm3_finish(ctx, dgst)
+    print '(a,*(4z0.2,:,1x))', '"abcd"*4: ', dgst
+    ! DEBE9FF9 2275B8A1 38604889 C18E5A4D 6FDB70E5 387E5765 293DCBA3 9C0C5732
 end program main

--- a/src/SM3.f90
+++ b/src/SM3.f90
@@ -6,38 +6,180 @@
 !> SM3/MD5 哈希算法 / GmSSL SM3/MD5 杂凑算法接口 <br>
 module SM3_module
 
-    use, intrinsic :: iso_c_binding, only: c_signed_char, c_size_t
+    use, intrinsic :: iso_c_binding, only: c_signed_char, c_size_t, c_int32_t, c_int64_t, c_int8_t
     implicit none
 
     private
-    public :: SM3, MD5
+    public :: MD5_CTX, MD5_DIGEST_SIZE, MD5_BLOCK_SIZE, MD5_STATE_WORDS
+    public :: md5_digest, md5_init, md5_update, md5_finish
+    public :: SM3_DIGEST_SIZE, SM3_BLOCK_SIZE, SM3_STATE_WORDS, SM3_HMAC_SIZE
+    public :: SM3_CTX, SM3_HMAC_CTX, SM3_KDF_CTX
+    public :: sm3_digest, sm3_init, sm3_update, sm3_finish
+    public :: sm3_hmac, sm3_hmac_init, sm3_hmac_update, sm3_hmac_finish
+    public :: sm3_kdf_init, sm3_kdf_update, sm3_kdf_finish
+    public :: hex_to_bytes
+
+    integer, parameter :: MD5_DIGEST_SIZE = 16
+    integer, parameter :: MD5_BLOCK_SIZE = 64
+    integer, parameter :: MD5_STATE_WORDS = MD5_BLOCK_SIZE/c_int32_t
+
+    integer, parameter :: SM3_DIGEST_SIZE = 32
+    integer, parameter :: SM3_BLOCK_SIZE = 64
+    integer, parameter :: SM3_STATE_WORDS = 8
+    integer, parameter :: SM3_HMAC_SIZE = SM3_DIGEST_SIZE
+
+    type, bind(c) :: MD5_CTX
+        integer(c_int32_t) :: state(MD5_STATE_WORDS)
+        integer(c_int64_t) :: nblocks
+        integer(c_int8_t) :: block(MD5_BLOCK_SIZE)
+        integer(c_size_t) :: num
+    end type MD5_CTX
+
+    type, bind(c) :: SM3_CTX
+        integer(c_int32_t) :: digest(SM3_STATE_WORDS)
+        integer(c_int64_t) :: nblocks
+        integer(c_int8_t) :: block(SM3_BLOCK_SIZE)
+        integer(c_size_t) :: num
+    end type SM3_CTX
+
+    type, bind(c) :: SM3_HMAC_CTX
+        type(SM3_CTX) :: sm3_ctx
+        integer(c_int8_t) :: key(SM3_BLOCK_SIZE)
+    end type SM3_HMAC_CTX
+
+    type, bind(c) :: SM3_KDF_CTX
+        type(SM3_CTX) :: sm3_ctx
+        integer(c_size_t) :: outlen
+    end type SM3_KDF_CTX
 
     interface
+
+        subroutine sm3_init(ctx) bind(c, name='sm3_init')
+            import :: SM3_CTX
+            type(SM3_CTX), intent(inout) :: ctx
+        end subroutine sm3_init
+
+        subroutine sm3_update(ctx, data, datalen) bind(c, name='sm3_update')
+            import :: SM3_CTX, c_int8_t, c_size_t
+            type(SM3_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(in) :: data(*)
+            integer(c_size_t), intent(in), value :: datalen
+        end subroutine sm3_update
+
+        subroutine sm3_finish(ctx, dgst) bind(c, name='sm3_finish')
+            import :: SM3_CTX, c_int8_t, SM3_DIGEST_SIZE
+            type(SM3_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(out) :: dgst(SM3_DIGEST_SIZE)
+        end subroutine sm3_finish
 
         !> SM3 Hash <br>
         !> SM3 杂凑算法
         !> 概述：对长度为 l (l < 2^64) 比特的消息 m，SM3 杂凑算法经过填充和迭代压缩，生成杂凑值，杂凑值长度为 256 比特 (32 字节)。
-        subroutine SM3(msg, msglen, dgst) bind(c, name='sm3_digest')
-            import :: c_signed_char, c_size_t
-            integer(c_signed_char), intent(in) :: msg(*)    !! Message <br>
-                                                            !! 输入消息
-            integer(c_size_t), intent(in), value :: msglen  !! Message length <br>
-                                                            !! 消息长度
-            integer(c_signed_char), intent(out) :: dgst(32) !! Hash value <br>
-                                                            !! 杂凑值
-        end subroutine SM3
+        subroutine sm3_digest(msg, msglen, dgst) bind(c, name='sm3_digest')
+            import :: c_int8_t, c_size_t, SM3_DIGEST_SIZE
+            integer(c_int8_t), intent(in) :: msg(*)                 !! Message <br>
+                                                                    !! 输入消息
+            integer(c_size_t), intent(in), value :: msglen          !! Message length <br>
+                                                                    !! 消息长度
+            integer(c_int8_t), intent(out) :: dgst(SM3_DIGEST_SIZE) !! Hash value <br>
+                                                                    !! 杂凑值
+        end subroutine sm3_digest
+
+        subroutine sm3_hmac_init(ctx, key, keylen) bind(c, name='sm3_hmac_init')
+            import :: SM3_HMAC_CTX, c_int8_t, c_size_t
+            type(SM3_HMAC_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(in) :: key(*)
+            integer(c_size_t), intent(in), value :: keylen
+        end subroutine sm3_hmac_init
+
+        subroutine sm3_hmac_update(ctx, data, datalen) bind(c, name='sm3_hmac_update')
+            import :: SM3_HMAC_CTX, c_int8_t, c_size_t
+            type(SM3_HMAC_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(in) :: data(*)
+            integer(c_size_t), intent(in), value :: datalen
+        end subroutine sm3_hmac_update
+
+        subroutine sm3_hmac_finish(ctx, mac) bind(c, name='sm3_hmac_finish')
+            import :: SM3_HMAC_CTX, c_int8_t, SM3_HMAC_SIZE
+            type(SM3_HMAC_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(out) :: mac(SM3_HMAC_SIZE)
+        end subroutine sm3_hmac_finish
+
+        subroutine sm3_hmac(key, keylen, data, datalen, mac) bind(c, name='sm3_hmac')
+            import :: c_int8_t, c_size_t, SM3_HMAC_SIZE
+            import :: SM3_HMAC_CTX
+            integer(c_int8_t), intent(in) :: key(*)              !! Key <br>
+                                                                 !! 密钥
+            integer(c_size_t), intent(in), value :: keylen       !! Key length <br>
+                                                                 !! 密钥长度
+            integer(c_int8_t), intent(in) :: data(*)             !! Message <br>
+                                                                 !! 输入消息
+            integer(c_size_t), intent(in), value :: datalen      !! Message length <br>
+                                                                 !! 消息长度
+            integer(c_int8_t), intent(out) :: mac(SM3_HMAC_SIZE) !! MAC <br>
+                                                                 !! 消息认证码
+        end subroutine sm3_hmac
+
+        subroutine sm3_kdf_init(ctx, outlen) bind(c, name='sm3_kdf_init')
+            import :: SM3_KDF_CTX, c_size_t
+            type(SM3_KDF_CTX), intent(inout) :: ctx
+            integer(c_size_t), intent(in), value :: outlen
+        end subroutine sm3_kdf_init
+
+        subroutine sm3_kdf_update(ctx, data, datalen) bind(c, name='sm3_kdf_update')
+            import :: SM3_KDF_CTX, c_int8_t, c_size_t
+            type(SM3_KDF_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(in) :: data(*)
+            integer(c_size_t), intent(in), value :: datalen
+        end subroutine sm3_kdf_update
+
+        subroutine sm3_kdf_finish(ctx, out) bind(c, name='sm3_kdf_finish')
+            import :: SM3_KDF_CTX, c_int8_t
+            type(SM3_KDF_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(out) :: out(*)
+        end subroutine sm3_kdf_finish
+
+        subroutine md5_init(ctx) bind(c, name='md5_init')
+            import :: MD5_CTX
+            type(MD5_CTX), intent(inout) :: ctx
+        end subroutine md5_init
+
+        subroutine md5_update(ctx, data, datalen) bind(c, name='md5_update')
+            import :: MD5_CTX, c_int8_t, c_size_t
+            type(MD5_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(in) :: data(*)
+            integer(c_size_t), intent(in), value :: datalen
+        end subroutine md5_update
+
+        subroutine md5_finish(ctx, dgst) bind(c, name='md5_finish')
+            import :: MD5_CTX, c_int8_t, MD5_DIGEST_SIZE
+            type(MD5_CTX), intent(inout) :: ctx
+            integer(c_int8_t), intent(out) :: dgst(MD5_DIGEST_SIZE)
+        end subroutine md5_finish
 
         !> MD5 Hash <br>
         !> MD5 杂凑算法
-        subroutine MD5(msg, msglen, dgst) bind(c, name='md5_digest')
-            import :: c_signed_char, c_size_t
-            integer(c_signed_char), intent(in) :: msg(*)    !! Message <br>
-                                                            !! 输入消息
-            integer(c_size_t), intent(in), value :: msglen  !! Message length <br>
-                                                            !! 消息长度
-            integer(c_signed_char), intent(out) :: dgst(16) !! Hash value <br>
-                                                            !! 杂凑值
-        end subroutine MD5
+        subroutine md5_digest(msg, msglen, dgst) bind(c, name='md5_digest')
+            import :: c_int8_t, c_size_t, MD5_DIGEST_SIZE
+            integer(c_int8_t), intent(in) :: msg(*)                 !! Message <br>
+                                                                    !! 输入消息
+            integer(c_size_t), intent(in), value :: msglen          !! Message length <br>
+                                                                    !! 消息长度
+            integer(c_int8_t), intent(out) :: dgst(MD5_DIGEST_SIZE) !! Hash value <br>
+                                                                    !! 杂凑值
+        end subroutine md5_digest
+
+        subroutine hex_to_bytes(in, inlen, out, outlen) bind(c, name='hex_to_bytes')
+            import :: c_int8_t, c_size_t, c_signed_char
+            character(kind=c_signed_char), intent(in) :: in(*) !! Hex string <br>
+                                                               !! 十六进制字符串
+            integer(c_size_t), intent(in), value :: inlen      !! Hex string length <br>
+                                                               !! 十六进制字符串长度
+            integer(c_int8_t), intent(out) :: out(*)           !! Bytes <br>
+                                                               !! 字节
+            integer(c_size_t), intent(in), value :: outlen     !! Bytes length <br>
+                                                               !! 字节长度
+        end subroutine hex_to_bytes
 
     end interface
 


### PR DESCRIPTION
md5还是得有update接口才好用，所以添加了这些接口。此外，还做了一些修改：

- 将`MD5`函数改名为`md5_digest`，`SM3`改名为`sm3_digest`，为了和c语言接口保持一致，
- 使用`c_int8_t`而不是`c_signed_char`，因为c的接口是`uint8_t`，
- 添加了`MD5_DIGEST_SIZE`等常数，而不是直接使用数字，
- 顺便添加了`sm3_hmac`, `sm3_kdf`相关的接口，虽然我并不懂他们是干什么用的。